### PR TITLE
fix(username): fix username in emissary command response

### DIFF
--- a/app.js
+++ b/app.js
@@ -87,7 +87,7 @@ client.on("chat", function (channel, userstate, message, self) {
         }
         commandTwitch.updateSpam('emissary');
         commandTwitch.emissary.getMessage().then(function (messageToSend) {
-            messageToSend = userstate['display-name'] + ' > ' + messageToSend;
+            messageToSend = command.target + ' > ' + messageToSend;
             client.say(channel, messageToSend);
         }).catch(console.warn);
         break;


### PR DESCRIPTION
This patch fix the response username returned by the emissary command (the command's potential target was never use).