### PR TITLE
tech(Blizzard API): add Blizzard API and Auth for future use

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -7,6 +7,14 @@
   "openweather": {
     "key": ""
   },
+  "blizzard": {
+    "oauth": {
+      "client_id": "",
+      "client_secret": "",
+      "grant_type": "client_credentials",
+      "token_url": "https://eu.battle.net/oauth/token"
+    }
+  },
   "db": {
     "music": {
       "host": "localhost",

--- a/libs/blizzard.js
+++ b/libs/blizzard.js
@@ -3,8 +3,6 @@ const request = require('request');
 
 const Blizzard = require('blizzard.js');
 
-const NBR_MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
-
 let savedAccessToken = null;
 
 // See https://github.com/benweier/blizzard.js/blob/master/API.md for details about available API requests
@@ -40,7 +38,7 @@ module.exports.getAccessToken = function() {
             // {"access_token":"xxxxxxxxxxxxxxxx","token_type":"bearer","expires_in":2591920}
             savedAccessToken = {
                 token: body.access_token,
-                expireDate: new Date(Date.now() + NBR_MILLISECONDS_IN_ONE_DAY), // keep access_token only for 24h
+                expireDate: new Date(Date.now() + (body.expires_in * 1000)), // body.expires_in is in seconds
             }
 
             resolve(body.access_token);

--- a/libs/blizzard.js
+++ b/libs/blizzard.js
@@ -1,0 +1,49 @@
+const config = require('config');
+const request = require('request');
+
+const Blizzard = require('blizzard.js');
+
+const NBR_MILLISECONDS_IN_ONE_DAY = 24 * 60 * 60 * 1000;
+
+let savedAccessToken = null;
+
+// See https://github.com/benweier/blizzard.js/blob/master/API.md for details about available API requests
+module.exports.api = Blizzard.initialize({ apikey: config.get('blizzard.oauth.client_id') });
+
+module.exports.getAccessToken = function() {
+    return new Promise((resolve, reject) => {
+
+        const now = new Date();
+        if (savedAccessToken && savedAccessToken.token && savedAccessToken.expireDate && savedAccessToken.expireDate > now) {
+            // If saved token is not expired, return it without asking a new one.
+            return resolve(savedAccessToken.token);
+        }
+
+        request.post({
+            url: config.get('blizzard.oauth.token_url'),
+            form: {
+                client_id: config.get('blizzard.oauth.client_id'),
+                client_secret: config.get('blizzard.oauth.client_secret'),
+                grant_type: config.get('blizzard.oauth.grant_type'),
+            },
+            json: true
+        }, function (error, response, body) {
+            if (error) {
+                return reject(error);
+            }
+
+            if (response.statusCode != 200) {
+                return reject(body);
+            }
+
+            // Blizzard oauth token endpoint return someting like this :
+            // {"access_token":"xxxxxxxxxxxxxxxx","token_type":"bearer","expires_in":2591920}
+            savedAccessToken = {
+                token: body.access_token,
+                expireDate: new Date(Date.now() + NBR_MILLISECONDS_IN_ONE_DAY), // keep access_token only for 24h
+            }
+
+            resolve(body.access_token);
+        });
+    });
+};

--- a/libs/index.js
+++ b/libs/index.js
@@ -1,0 +1,1 @@
+module.exports.blizzard = require('./blizzard');

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "@types/node": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-9.3.0.tgz",
-      "integrity": "sha512-wNBfvNjzsJl4tswIZKXCFQY0lss9nKUyJnG6T94X/eqjRgI2jHZ4evdjhQYBSan/vGtF6XVXPApOmNH2rf0KKw=="
+      "integrity": "sha1-OhKc2nxOXfJAlwJiaJLLS5ZUbdU="
     },
     "ajv": {
       "version": "5.5.2",
@@ -43,7 +43,7 @@
     "async": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "integrity": "sha1-YaKau2/MAm/qd+VtHG7FOnlZUfQ=",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -63,6 +63,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "axios": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "requires": {
+        "follow-redirects": "1.3.0",
+        "is-buffer": "1.1.6"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
@@ -78,6 +87,14 @@
       "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
       "requires": {
         "readable-stream": "2.0.6"
+      }
+    },
+    "blizzard.js": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/blizzard.js/-/blizzard.js-2.1.0.tgz",
+      "integrity": "sha512-g6pacNctjjhCAYLCpq1OtlLSmf7VgplcvMar8HgexQKPt5fhBn+Jx5g8eaVP8Cq9nwYEpIfvwV2UccCUFsOk6Q==",
+      "requires": {
+        "axios": "0.17.1"
       }
     },
     "boolbase": {
@@ -144,7 +161,7 @@
     "commander": {
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA=="
+      "integrity": "sha1-D1lGxCftnsDZGka7ne9T5UZQ5VU="
     },
     "config": {
       "version": "1.29.0",
@@ -171,7 +188,7 @@
         "boom": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
           "requires": {
             "hoek": "4.2.0"
           }
@@ -200,6 +217,14 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
         "assert-plus": "1.0.0"
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
       }
     },
     "delayed-stream": {
@@ -284,6 +309,14 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "follow-redirects": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.3.0.tgz",
+      "integrity": "sha1-9oSHH8EW0uMp/aVe9naH9Pq8kFw=",
+      "requires": {
+        "debug": "3.1.0"
+      }
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -345,7 +378,7 @@
     "hawk": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -356,7 +389,7 @@
     "hoek": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
     },
     "htmlparser2": {
       "version": "3.9.2",
@@ -386,10 +419,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "is-my-json-valid": {
       "version": "2.17.1",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
-      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
+      "integrity": "sha1-PamJFKcKIvCoVj7xURokbG/FVHE=",
       "requires": {
         "generate-function": "2.0.0",
         "generate-object-property": "1.2.0",
@@ -485,7 +523,12 @@
     "moment": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+      "integrity": "sha1-1usaRsvMFKKy+UNBEsH/iQfzE/0="
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nth-check": {
       "version": "1.0.1",
@@ -518,7 +561,7 @@
     "parse5": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
-      "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+      "integrity": "sha1-BC95L/3TaFFVHPTp4Gazh0q0W1w=",
       "requires": {
         "@types/node": "9.3.0"
       }
@@ -603,7 +646,7 @@
     "postgres-interval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.1.1.tgz",
-      "integrity": "sha512-OkuCi9t/3CZmeQreutGgx/OVNv9MKHGIT5jH8KldQ4NLYXkvmT9nDVxEuCENlNwhlGPE374oA/xMqn05G49pHA==",
+      "integrity": "sha1-rNsPiXtLHG5JbZ1OCoU+HEKPBvA=",
       "requires": {
         "xtend": "4.0.1"
       }
@@ -621,7 +664,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
     },
     "readable-stream": {
       "version": "2.0.6",
@@ -639,7 +682,7 @@
     "request": {
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -668,7 +711,7 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "semver": {
       "version": "4.3.2",
@@ -678,7 +721,7 @@
     "sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
       "requires": {
         "hoek": "4.2.0"
       }
@@ -686,7 +729,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "requires": {
         "through": "2.3.8"
       }
@@ -909,7 +952,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/WFrancois/twitch-bot#readme",
   "dependencies": {
+    "blizzard.js": "^2.1.0",
     "cheerio": "^1.0.0-rc.2",
     "config": "^1.29.0",
     "moment": "^2.20.1",


### PR DESCRIPTION
**Summary**

This patch add a way to call the official Blizzard API (https://dev.battle.net/io-docs) for future use.

**Important notes**

Blizzard's API as it is implemented in this patch **needs two keys to works**, both of them have to be in the proper config file. Those keys are issued by Blizzard to enforce the oauth authentification (more details [here](https://dev.battle.net/docs/read/oauth). See **New configuration values** part for specifics.

Currently, **the access token generated by the two keys is kept for 24 hours**. That way, the server will only request a new access token once per day. We could decide to request a new one with each API request to be extremely safe about the token viability (I don't advise that at all). We could also use the real expiration time : 30 days, even if I consider quite unsafe to do so, considering that if the token is revoked, the implementation won't work until the exact 30 days time. Feel free to comment about that call :) 

**Tasks**

- [x] Follow existing code architecture and practice.
- [x] Functional test.

**New configuration values** 
- _client_id_: API account specific key (found [here](https://dev.battle.net/apps/mykeys) once logged).
- _client_secret_: Application specific key (found [here](https://dev.battle.net/apps/mykeys) once logged).
- _grant_type_: Authentification type, we are using _client_credentials_ for now.
- _token_url_: URL to retrieve the access_token from Blizzard's oauth service.
  